### PR TITLE
fully switch to new countsMatrix, remove transition functions

### DIFF
--- a/demo/demo.tsx
+++ b/demo/demo.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { CellPop } from "../src/CellPopComponent";
 import { CellPopData } from "../src/cellpop-schema";
 import { loadHuBMAPData } from "../src/dataLoading/dataHuBMAP";
-import { translateDataToObjectFormat } from "../src/dataLoading/dataWrangling";
 import { testData, testData_200_300 } from "./testData";
 
 import ScatterPlot from "@mui/icons-material/ScatterPlot";
@@ -10,7 +9,7 @@ import TableChartIcon from "@mui/icons-material/TableChartRounded";
 import { GridSizeTuple } from "../src/contexts/DimensionsContext";
 
 function Demo() {
-  const [data, setData] = useState<CellPopData>(translateDataToObjectFormat(testData) as CellPopData);
+  const [data, setData] = useState<CellPopData>(testData as CellPopData);
 
   // data
   const uuids = [
@@ -54,11 +53,7 @@ function Demo() {
     if (!data) {
       loadHuBMAPData(uuids)
         .then((data) => {
-          // setData(data!);
-          if (data) {
-            const dataPreviousFormat = translateDataToObjectFormat(data) as CellPopData;
-            setData(dataPreviousFormat!);
-          }
+          setData(data!);
         })
         .catch((error) => {
           console.error(error);

--- a/src/cellpop-schema.ts
+++ b/src/cellpop-schema.ts
@@ -20,30 +20,11 @@ export type CellPopData = {
   extendedChart: extendedChart;
 };
 
-// temporary for data change
-export type CellPopDataFlexible = {
-  rowNames: string[];
-  rowNamesRaw: string[];
-  rowNamesWrapped: RowNamesWrapped[];
-  colNames: string[];
-  colNamesRaw: string[];
-  colNamesWrapped: ColNamesWrapped[];
-  countsMatrixOrder: string[];
-  countsMatrix: CountsMatrixValue[] | CountsMatrixValueOld[];
-  countsMatrixFractions: CountsMatrixFractions | CountsMatrixFractionsOld;
-  metadata: MetaData;
-  extendedChart: extendedChart;
-};
-
 export type RowNamesWrapped = { row: string };
 
 export type ColNamesWrapped = { col: string };
 
-// temporary for data change
 export type CountsMatrixValue = [string, string, number]
-
-// temporary for data change
-export type CountsMatrixValueOld = {row: string, col: string, value: number}
 
 export type CountsTotalRowValue = {
   row: string;
@@ -58,11 +39,6 @@ export type CountsTotalColValue = {
 export type CountsMatrixFractions = {
   row: CountsMatrixValue[];
   col: CountsMatrixValue[];
-};
-
-export type CountsMatrixFractionsOld = {
-  row: CountsMatrixValueOld[];
-  col: CountsMatrixValueOld[];
 };
 
 export type MetaData<T extends number | string> = {

--- a/src/cellpop-schema.ts
+++ b/src/cellpop-schema.ts
@@ -15,7 +15,6 @@ export type CellPopData = {
   colNamesWrapped: ColNamesWrapped[];
   countsMatrixOrder: string[]
   countsMatrix: CountsMatrixValue[];
-  countsMatrixFractions: CountsMatrixFractions;
   metadata: MetaData;
   extendedChart: extendedChart;
 };
@@ -34,11 +33,6 @@ export type CountsTotalRowValue = {
 export type CountsTotalColValue = {
   col: string;
   countTotal: number;
-};
-
-export type CountsMatrixFractions = {
-  row: CountsMatrixValue[];
-  col: CountsMatrixValue[];
 };
 
 export type MetaData<T extends number | string> = {

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -418,7 +418,7 @@ const getDerivedStatesSelector = (state: DataContextStore) => {
   const columnMaxes: Record<string, number> = {};
   let maxCount = 0;
   const { removedRows, removedColumns } = state;
-  state.data.countsMatrix.forEach(({ row, col, value }) => {
+  state.data.countsMatrix.forEach(([ row, col, value ]) => {
     if (removedRows.has(row) || removedColumns.has(col)) {
       return;
     }
@@ -441,7 +441,7 @@ const getDerivedStatesMemo = memoize(getDerivedStatesSelector);
 
 const getDataMap = memoize((state: DataContextStore) => {
   const dataMap: Record<DataMapKey, number> = {};
-  state.data.countsMatrix.forEach(({ row, col, value }) => {
+  state.data.countsMatrix.forEach(([ row, col, value ]) => {
     dataMap[`${row}-${col}`] = value;
   });
   return dataMap;
@@ -450,7 +450,7 @@ const getDataMap = memoize((state: DataContextStore) => {
 const getRowFractionDataMap = memoize((state: DataContextStore) => {
   const dataMap: Record<DataMapKey, number> = {};
   const { rowCounts } = getDerivedStatesSelector(state);
-  state.data.countsMatrix.forEach(({ row, col, value }) => {
+  state.data.countsMatrix.forEach(([ row, col, value ]) => {
     dataMap[`${row}-${col}`] = value / rowCounts[row];
   });
   return dataMap;
@@ -459,7 +459,7 @@ const getRowFractionDataMap = memoize((state: DataContextStore) => {
 const getColumnFractionDataMap = memoize((state: DataContextStore) => {
   const dataMap: Record<DataMapKey, number> = {};
   const { columnCounts } = getDerivedStatesSelector(state);
-  state.data.countsMatrix.forEach(({ row, col, value }) => {
+  state.data.countsMatrix.forEach(([ row, col, value ]) => {
     dataMap[`${row}-${col}`] = value / columnCounts[col];
   });
   return dataMap;

--- a/src/dataLoading/dataWrangling.ts
+++ b/src/dataLoading/dataWrangling.ts
@@ -69,7 +69,6 @@ function loadDataWrapper(data: CellPopData, ordering?: dataOrdering) {
   }
   wrapRowNames(data);
   wrapColNames(data);
-  calculateFractions(data);
 
   // copy's
   data.rowNamesRaw = [...data.rowNames];
@@ -144,38 +143,4 @@ export function resetRowNames(data: CellPopData) {
 export function resetColNames(data: CellPopData) {
   data.colNames = [...data.colNamesRaw];
   wrapColNames(data);
-}
-
-export function calculateFractions(data: CellPopData) {
-  const countsMatrixRowFractions = [];
-  const countsMatrixColFractions = [];
-  for (const row of data.rowNames) {
-    const countsMatrixRow = data.countsMatrix.filter((r) => r[0] === row);
-    const countsMatrixRowValues = countsMatrixRow.map((r) => r[2]);
-    const countsMatrixRowValuesSum = countsMatrixRowValues.reduce(
-      (a, b) => a + b,
-      0,
-    );
-    const countsMatrixRowFraction = countsMatrixRow.map((r) => ([
-      r[0], r[1], r[2] / countsMatrixRowValuesSum,
-    ] as CountsMatrixValue));
-    countsMatrixRowFractions.push(...countsMatrixRowFraction);
-  }
-
-  for (const col of data.colNames) {
-    const countsMatrixCol = data.countsMatrix.filter((r) => r[1] === col);
-    const countsMatrixColValues = countsMatrixCol.map((r) => r[2]);
-    const countsMatrixColValuesSum = countsMatrixColValues.reduce(
-      (a, b) => a + b,
-      0,
-    );
-    const countsMatrixColFraction = countsMatrixCol.map((r) => ([
-      r[0], r[1], r[2] / countsMatrixColValuesSum,
-    ] as CountsMatrixValue));
-    countsMatrixColFractions.push(...countsMatrixColFraction);
-  }
-  data.countsMatrixFractions = {
-    row: countsMatrixRowFractions,
-    col: countsMatrixColFractions,
-  };
 }

--- a/src/dataLoading/dataWrangling.ts
+++ b/src/dataLoading/dataWrangling.ts
@@ -10,7 +10,6 @@
 
 import {
   CellPopData,
-  CellPopDataFlexible,
   CountsMatrixValue,
   MetaData,
   dataOrdering,
@@ -179,27 +178,4 @@ export function calculateFractions(data: CellPopData) {
     row: countsMatrixRowFractions,
     col: countsMatrixColFractions,
   };
-}
-
-
-// Temporary new -> old data conversion
-export function translateDataToObjectFormat(data: CellPopData) {
-  const countsMatrixOld = translateCountsMatrixToObjectFormat(data.countsMatrix);
-  const dataOld = {...data, countsMatrix: countsMatrixOld} as CellPopDataFlexible;
-  if (data.countsMatrixFractions) {
-    const countsMatrixFractionsOld = {
-      row: translateCountsMatrixToObjectFormat(data.countsMatrixFractions.row),
-      col: translateCountsMatrixToObjectFormat(data.countsMatrixFractions.col)
-    }
-    dataOld.countsMatrixFractions = countsMatrixFractionsOld;
-  }
-  return dataOld;
-}
-
-export function translateCountsMatrixToObjectFormat(countsMatrix: CountsMatrixValue[]) {
-  const countsMatrixOld = [] as {row: string, col: string, value: number}[]
-  for (const val of countsMatrix) {
-    countsMatrixOld.push({row: val[0], col: val[1], value: val[2]});
-  }
-  return countsMatrixOld;
 }


### PR DESCRIPTION
This PR removes the temporary "translateDataToObjectFormat", and instead changes the DataContext to use the array based countsMatrix instead of an object based countsMatrix.